### PR TITLE
Enh #1345

### DIFF
--- a/cohorts/views.py
+++ b/cohorts/views.py
@@ -464,7 +464,7 @@ def metadata_counts_platform_list(req_filters, cohort_id, user, limit):
         cursor.execute(query_str, value_tuple)
         stop = time.time()
         logger.debug("[BENCHMARKING] Time to query platforms in metadata_counts_platform_list for cohort '" +
-                     cohort_id + "': " + (stop - start).__str__())
+                     cohort_id if cohort_id is not None else 'None' + "': " + (stop - start).__str__())
         for row in cursor.fetchall():
             item = {
                 'DNAseq_data': str(row['DNAseq_data']),
@@ -479,9 +479,11 @@ def metadata_counts_platform_list(req_filters, cohort_id, user, limit):
         cursor.close()
         db.close()
 
-        return {'items': data, 'count': counts_and_total['counts'],
+        result = {'items': data, 'count': counts_and_total['counts'],
                 'participants': counts_and_total['participants'],
                 'total': counts_and_total['total']}
+
+        return result
 
     except Exception as e:
         print traceback.format_exc()

--- a/cohorts/views.py
+++ b/cohorts/views.py
@@ -353,7 +353,6 @@ def query_samples_and_studies(parameter, bucket_by=None):
 def metadata_counts_platform_list(req_filters, cohort_id, user, limit):
     """ Used by the web application."""
     filters = {}
-    result = {}
     sample_ids = None
     samples_by_study = None
 
@@ -480,11 +479,9 @@ def metadata_counts_platform_list(req_filters, cohort_id, user, limit):
         cursor.close()
         db.close()
 
-        result = {'items': data, 'count': counts_and_total['counts'],
+        return {'items': data, 'count': counts_and_total['counts'],
                 'participants': counts_and_total['participants'],
                 'total': counts_and_total['total']}
-
-        return result
 
     except Exception as e:
         print traceback.format_exc()
@@ -1559,5 +1556,8 @@ def get_metadata(request):
 
     # results = urlfetch.fetch(data_url, method=urlfetch.POST, payload=json.dumps(payload), deadline=60, headers={'Content-Type': 'application/json'})
     results = metadata_counts_platform_list(filters, cohort, user, limit)
+
+    if not results:
+        results = {}
 
     return JsonResponse(results)

--- a/cohorts/views.py
+++ b/cohorts/views.py
@@ -353,6 +353,7 @@ def query_samples_and_studies(parameter, bucket_by=None):
 def metadata_counts_platform_list(req_filters, cohort_id, user, limit):
     """ Used by the web application."""
     filters = {}
+    result = {}
     sample_ids = None
     samples_by_study = None
 


### PR DESCRIPTION
This tests the possibility of using views without endpoints to display queried data. This specific test involves copying metadata_counts_platform_list, the endpoint which backs the tree bargraph and parallel coordinates plots on cohort pages, into cohorts/views.py and altering the get_metadata view to return the result of this new 'view'. This involved duping several other helper methods and importing some things from api/metadata, and it appears to work fine in a dev environment. 

This is only intended to test this option, and wouldn't be for production; per a conversation with @phyllers, if this works we would ideally want to make an entirely separate Django app for this (called 'metadata' perhaps) which would house its own set of views that can provide this kind of queried information. This would make it much easier to extend this kind of functionality and not bloat the other app-specific views.