### PR TITLE
Filter fix

### DIFF
--- a/cohorts/views.py
+++ b/cohorts/views.py
@@ -1508,5 +1508,35 @@ def get_metadata(request):
 
     if not results:
         results = {}
+    else:
+
+        data_attr = [
+            'DNA_sequencing',
+            'RNA_sequencing',
+            'miRNA_sequencing',
+            'Protein',
+            'SNP_CN',
+            'DNA_methylation',
+        ]
+
+        attr_details = {
+            'RNA_sequencing': [],
+            'miRNA_sequencing': [],
+            'DNA_methylation': [],
+        }
+
+        for item in results['count']:
+            key = item['name']
+            values = item['values']
+
+            if key.startswith('has_'):
+                data_availability_sort(key, values, data_attr, attr_details)
+
+        for key, value in attr_details.items():
+            results['count'].append({
+                'name': key,
+                'values': value,
+                'id': None
+            })
 
     return JsonResponse(results)


### PR DESCRIPTION
So somehow this commit didn't make it into the last PR for this, I think maybe because I was pushing at the same time it was being approved. At any rate: final round of fixes for the 'Data Type' filter panel, absent the refactoring for the Sprint 7 ticket.