### PR TITLE
Quick fix

### DIFF
--- a/cohorts/views.py
+++ b/cohorts/views.py
@@ -148,6 +148,7 @@ def get_participant_count(filter="", cohort_id=None):
 
     except Exception as e:
         print traceback.format_exc()
+    finally:
         if cursor: cursor.close()
         if db and db.open: db.close()
 

--- a/cohorts/views.py
+++ b/cohorts/views.py
@@ -176,6 +176,8 @@ def count_metadata(user, cohort_id=None, sample_ids=None, filters=None):
     db = get_sql_connection()
     django.setup()
 
+    cursor = None
+
     try:
         # Add TCGA attributes to the list of available attributes
         if 'user_studies' not in filters or 'tcga' in filters['user_studies']['values']:

--- a/cohorts/views.py
+++ b/cohorts/views.py
@@ -377,6 +377,8 @@ def metadata_counts_platform_list(req_filters, cohort_id, user, limit):
 
     data = []
 
+    cursor = None
+
     try:
         db = get_sql_connection()
         cursor = db.cursor(MySQLdb.cursors.DictCursor)


### PR DESCRIPTION
- Straightened up some cursor and connection closure issues

If we can put this into Sprint 6 we should, since get_participant_count is called a lot.