### PR TITLE
Bug 1466

### DIFF
--- a/cohorts/views.py
+++ b/cohorts/views.py
@@ -350,9 +350,6 @@ def count_metadata(user, cohort_id=None, sample_ids=None, filters=None):
 
                 exclusionary_filter[filter.split(':')[-1]] = ex_where_clause
 
-        print >> sys.stdout, filters.__str__()
-        print >> sys.stdout, unfiltered_attr.__str__()
-
         query_table_name = None
         tmp_table_name = None
 
@@ -378,7 +375,6 @@ def count_metadata(user, cohort_id=None, sample_ids=None, filters=None):
                 params_tuple += where_clause['value_tuple']
 
             make_tmp_table_str += ";"
-            print >> sys.stdout, make_tmp_table_str
             cursor.execute(make_tmp_table_str, params_tuple)
         else:
             query_table_name = 'metadata_samples'
@@ -424,7 +420,6 @@ def count_metadata(user, cohort_id=None, sample_ids=None, filters=None):
                         'params': exclusionary_filter[col_name]['value_tuple']})
 
         for query in count_query_set:
-            print >> sys.stdout, query.__str__()
             if 'params' in query and query['params'] is not None:
                 cursor.execute(query['query_str'], query['params'])
             else:
@@ -441,8 +436,6 @@ def count_metadata(user, cohort_id=None, sample_ids=None, filters=None):
             for row in cursor.fetchall():
                 counts[col_headers[0]]['counts'][row[0]] = int(row[1])
                 counts[col_headers[0]]['total'] += int(row[1])
-
-        print >> sys.stdout, counts.__str__()
 
         # Drop the temporary table, if we made one
         if tmp_table_name is not None:

--- a/cohorts/views.py
+++ b/cohorts/views.py
@@ -349,11 +349,14 @@ def count_metadata(user, cohort_id=None, sample_ids=None, filters=None):
                     col_name = key_map[key]
 
                 if should_be_queried:
-                    count_query_set.append(
-                        ('SELECT DISTINCT ms.%s, IF(counts.count IS NULL,0,counts.count) AS count FROM %s AS ms ' +
-                        'LEFT JOIN (SELECT DISTINCT %s, COUNT(1) as count FROM %s GROUP BY %s) as counts ON ' +
-                        'counts.%s = ms.%s;') % (col_name, 'metadata_samples', col_name, tmp_table_name, col_name,
-                                                 col_name, col_name,)
+                    count_query_set.append(("""
+                        SELECT DISTINCT IF(ms.%s IS NULL,'None',ms.%s) AS %s, IF(counts.count IS NULL,0,counts.count) AS
+                        count
+                        FROM %s AS ms
+                        LEFT JOIN (SELECT DISTINCT %s, COUNT(1) as count FROM %s GROUP BY %s) AS counts
+                        ON counts.%s = ms.%s OR (counts.%s IS NULL AND ms.%s IS NULL);
+                      """)
+                        % (col_name, col_name, col_name, 'metadata_samples', col_name, tmp_table_name, col_name, col_name, col_name, col_name, col_name)
                     )
 
         for query_str in count_query_set:

--- a/cohorts/views.py
+++ b/cohorts/views.py
@@ -312,7 +312,7 @@ def count_metadata(user, cohort_id=None, sample_ids=None, filters=None):
         cursor = db.cursor()
 
         # We need to perform 2 sets of queries: one with each filter excluded from the others, against the full
-        # metadata_samples/cohort JOIN, and one where all filters are applied to create a temporart table, and
+        # metadata_samples/cohort JOIN, and one where all filters are applied to create a temporary table, and
         # attributes *outside* that set are counted
 
         unfiltered_attr = []


### PR DESCRIPTION
- Metadata counting now has two branches, one for filters and one for unfiltered attributes. Unfiltered attributes count against all filters; filters do not count against themselves
- Sample and Participant counts always take into account the full filter set
- Unfiltered counts are run directly against metadata_samples, with a JOIN for cohorts
- A temporary table is only generated in the case of filters (cohorts count as a filter for these purposes, because they exclude members from the primary table)