### PR TITLE
Bugs 1444 & 1486

### DIFF
--- a/cohorts/views.py
+++ b/cohorts/views.py
@@ -450,7 +450,10 @@ def count_metadata(user, cohort_id=None, sample_ids=None, filters=None):
 
             for value, count in feature['values'].items():
                 if feature['name'].startswith('has_'):
-                    value = ('True' if (value and value != 'None') else 'False')
+                    if value and value != 'None':
+                        value = 'True'
+                    elif not value:
+                        value = 'False'
 
                 if feature['name'] in DISPLAY_NAME_DD:
                     value_list.append({'value': str(value), 'count': count, 'displ_name': DISPLAY_NAME_DD[feature['name']][str(value)]})

--- a/cohorts/views.py
+++ b/cohorts/views.py
@@ -449,10 +449,11 @@ def count_metadata(user, cohort_id=None, sample_ids=None, filters=None):
                 feature['values'] = normalize_bmi(feature['values'])
 
             for value, count in feature['values'].items():
+                # Convert all 1/'1' and 0/'0' values to True and False
                 if feature['name'].startswith('has_'):
-                    if value and value != 'None':
+                    if value == 1 or value == '1':
                         value = 'True'
-                    elif not value:
+                    elif value == 0  or value == '0':
                         value = 'False'
 
                 if feature['name'] in DISPLAY_NAME_DD:


### PR DESCRIPTION
- Made the fix to #1444/1#486 more robust
- Per the WebApp PR, NULL entries for Data type filters will not be lumped in with 'False', but will show as 'NA' like on the Donor tab