### PR TITLE
Bug 1228

### DIFF
--- a/cohorts/urls.py
+++ b/cohorts/urls.py
@@ -32,6 +32,7 @@ urlpatterns = [
     url(r'^clone_cohort/(?P<cohort_id>\d+)/',       views.clone_cohort, name='clone_cohort'),
     url(r'^share_cohort/$',                         views.share_cohort, name='share_cohorts'),
     url(r'^share_cohort/(?P<cohort_id>\d+)/',       views.share_cohort, name='share_cohort'),
+    url(r'^unshare_cohort/$',                       views.unshare_cohort, name='unshare_cohorts'),
     url(r'^unshare_cohort/(?P<cohort_id>\d+)/',     views.unshare_cohort, name='unshare_cohort'),
     url(r'^set_operation/',                         views.set_operation, name='set_operation'),
     url(r'^save_cohort_comment/',                   views.save_comment, name='save_cohort_comment'),


### PR DESCRIPTION
- Added URL unshare_cohorts/ which doesn't require an ID but does require 'cohorts', a JSONified list of cohort IDs
- unshare_cohort will no longer allow ownership permissions to be removed