### PR TITLE
User Data: Bad study table names

### DIFF
--- a/cohorts/views.py
+++ b/cohorts/views.py
@@ -525,22 +525,25 @@ def count_user_metadata(user, inc_filters=None, cohort_id=None):
     for study in Study.get_user_studies(user):
 
         include_study = True
-        study_obj = {'id': study.id, 'value': study.id, 'name': study.name, 'count': 0, 'metadata_samples': None, 'project': study.project.id, }
-        for tables in User_Data_Tables.objects.filter(study_id=study.id):
-            study_obj['metadata_samples'] = tables.metadata_samples_table
 
-            # Do not include studies that are low level data
-            datatype_query = "SELECT data_type from {0} where study_id={1}".format(tables.metadata_data_table, study.id)
-            cursor = db.cursor()
-            cursor.execute(datatype_query)
-            results = cursor.fetchall()
-            if len(results):
-                for row in results:
+        for tables in User_Data_Tables.objects.filter(study_id=study.id):
+            if 'user_' not in tables.metadata_samples_table:
+                logger.warn('[WARNING] User study mtadata_samples table may have a malformed name: '
+                    +(tables.metadata_samples_table.__str__() if tables.metadata_samples_table is not None else 'None')
+                    + ' for study '+str(study.id)+'; skipping')
+                include_study = False
+            else:
+                # Do not include studies that are low level data
+                datatype_query = ("SELECT data_type from %s where study_id=" % tables.metadata_data_table) + '%s'
+                cursor = db.cursor()
+                cursor.execute(datatype_query, (study.id,))
+                for row in cursor.fetchall():
                     if row[0] == 'low_level':
                         include_study = False
 
         if include_study:
-            user_data_counts['study']['values'].append(study_obj)
+            user_data_counts['study']['values'].append({'id': study.id, 'value': study.id, 'name': study.name,
+                'count': 0, 'metadata_samples': tables.metadata_samples_table, 'project': study.project.id,})
 
         study_count_query_str = "SELECT COUNT(DISTINCT sample_barcode) AS count FROM %s"
         participant_count_query_str = "SELECT COUNT(DISTINCT participant_barcode) AS count FROM %s"


### PR DESCRIPTION
- Instead of erroring, warn when we find a possibly malformed table name, log it, and skip that study