### PR TITLE
User Data: Set Intersection

### DIFF
--- a/cohorts/views.py
+++ b/cohorts/views.py
@@ -1689,7 +1689,8 @@ def set_operation(request):
                 for sample in cohort_samples:
                     if sample.sample_id not in sample_study_map:
                         sample_study_map[sample.sample_id] = []
-                    sample_study_map[sample.sample_id].append(sample.study.id)
+                    if sample.study.id not in sample_study_map[sample.sample_id]:
+                        sample_study_map[sample.sample_id].append(sample.study.id)
 
                 notes = 'Intersection of ' + cohorts[0].name
 
@@ -1700,15 +1701,15 @@ def set_operation(request):
                     cohort_samples = Samples.objects.filter(cohort=cohort)
 
                     for sample in cohort_samples:
-                        if sample.sample_id in sample_study_map:
+                        if sample.sample_id in sample_study_map and sample.study.id not in sample_study_map[sample.sample_id]:
                             sample_study_map[sample.sample_id].append(sample.study.id)
 
-                    cohort_samples_ids = cohort_samples_ids.intersection(Samples.objects.filter(cohort=cohorts[0]).values_list('sample_id',flat=True))
+                    cohort_samples_ids = cohort_samples_ids.intersection(Samples.objects.filter(cohort=cohort).values_list('sample_id',flat=True))
                     cohort_patients = cohort_patients.intersection(Patients.objects.filter(cohort=cohort).values_list('patient_id', flat=True))
 
                 cohort_sample_list = []
 
-                print >> sys.stdout, cohort_samples_ids.__str__()
+                print >> sys.stdout, 'unique ID set: '+cohort_samples_ids.__str__()
 
                 for sample in cohort_samples_ids:
                     if len(sample_study_map[sample]) > 1:

--- a/projects/models.py
+++ b/projects/models.py
@@ -79,6 +79,7 @@ class Project_Last_View(models.Model):
 
 
 class Study(models.Model):
+    id = models.AutoField(primary_key=True, null=False, blank=False)
     name = models.CharField(max_length=255)
     description = models.TextField(null=True, blank=True)
     active = models.BooleanField(default=True)
@@ -113,6 +114,23 @@ class Study(models.Model):
         last_view.save(False, True)
 
         return last_view
+
+    '''
+    Get the root/parent study of this study's extension hierarchy, and its depth
+    '''
+    def get_my_root_and_depth(self):
+        root = self.id
+        depth = 1
+        ancestor = self.extends
+
+        while ancestor is not None:
+            ancStudy = Study.objects.filter(id=ancestor)
+            ancestor = ancStudy.extends
+            depth += 1
+            root = ancStudy.id
+
+        return {'root': root, 'depth': depth}
+
 
     def get_status (self):
         status = 'Complete'


### PR DESCRIPTION
- Cohorts made from ISB-CGC samples will now save the study ID of the study in the projects_study table whose name corresponds to the Study column in metadata_samples and whose owner is 1 (i.e. isb-cgc). ***This will need to be retroactively applied to all extent cohorts with a script.***
- Extent cohorts with null study IDs should intersect correctly until the retroactive script is done
- If intersected cohorts contain samples whose barcodes match but whose study IDs do not, these studies will be examined to determine if they share the same hierarchy; if they do, then the sample with the highest order depth (i.e. furthest extended) will be added to the cohort
- If samples from cohorts with and without study IDs are compared, only the samples with study will be checked for shared study inheritance 