### PR TITLE
Set Ops benchmarking

### DIFF
--- a/cohorts/views.py
+++ b/cohorts/views.py
@@ -229,6 +229,7 @@ def get_sample_participant_list(user, inc_filters=None, cohort_id=None):
         else:
             filters[key] = inc_filters[key]
 
+
     # User data filters trump all other filters; if there are any which came along
     # with the rest, only those count
     if user_data_filters:
@@ -1744,6 +1745,8 @@ def set_operation(request):
             samples = Samples.objects.filter(cohort_id__in=ids).distinct().values_list('sample_id', 'study_id')
 
         elif op == 'intersect':
+
+            start = time.time()
             cohort_ids = request.POST.getlist('selected-ids')
             cohorts = Cohort.objects.filter(id__in=cohort_ids, active=True, cohort_perms__in=request.user.cohort_perms_set.all())
             request.user.cohort_perms_set.all()
@@ -1821,6 +1824,10 @@ def set_operation(request):
 
                 samples = cohort_sample_list
 
+                stop = time.time()
+
+                logger.debug('[BENCHMARKING] Time to build intersecting sample set: ' + (stop - start).__str__())
+
         elif op == 'complement':
             base_id = request.POST.get('base-id')
             subtract_ids = request.POST.getlist('subtract-ids')
@@ -1843,6 +1850,7 @@ def set_operation(request):
             notes += ' from %s.' % base_cohort.name
 
         if len(samples):
+            start = time.time()
             new_cohort = Cohort.objects.create(name=name)
             perm = Cohort_Perms(cohort=new_cohort, user=request.user, perm=Cohort_Perms.OWNER)
             perm.save()
@@ -1857,7 +1865,10 @@ def set_operation(request):
             Samples.objects.bulk_create(sample_list)
 
             # get the full resulting sample and patient ID set
+            startSI = time.time()
             samples_and_participants = get_sample_participant_list(request.user,None,new_cohort.id)
+            stopSI = time.time()
+            logger.debug('[BENCHMARKING] Time to get sample and participant list in set ops: '+(stopSI - startSI).__str__())
 
             # Store cohort to BigQuery
             project_id = settings.BQ_PROJECT_ID
@@ -1882,6 +1893,9 @@ def set_operation(request):
                 for cohort in subtracted_cohorts:
                     source = Source.objects.create(parent=cohort, cohort=new_cohort, type=Source.SET_OPS, notes=notes)
                     source.save()
+
+            stop = time.time()
+            logger.debug('[BENCHMARKING] Time to make cohort in set ops: '+(stop - start).__str__())
 
         else:
             message = 'Operation resulted in empty set of samples and patients. Cohort not created.'


### PR DESCRIPTION
Loglines for benchmarks in cohort intersection, so we can pinpoint the slowdown.