### PR TITLE
Security adjustment

### DIFF
--- a/cohorts/metadata_helpers.py
+++ b/cohorts/metadata_helpers.py
@@ -151,6 +151,11 @@ def get_metadata_value_set():
         if db and db.open: db.close()
 
 
+def validate_filter_key(col):
+    if ':' in col:
+        col = col.split(':')[1]
+    return col in METADATA_SHORTLIST['list']
+
 """
 BigQuery methods
 """

--- a/cohorts/views.py
+++ b/cohorts/views.py
@@ -1831,7 +1831,7 @@ def set_operation(request):
                                 elif sample.project.id not in sample_project_map[sample.sample_barcode]:
                                     sample_project_map[sample.sample_barcode].append(sample.project.id)
 
-                        cohort_samples_ids = cohort_samples_ids.intersection(Samples.objects.filter(cohort=cohort).values_list('sample_barcode','case_barcode'))
+                        cohort_samples_ids = cohort_samples_ids.intersection(set(Samples.objects.filter(cohort=cohort).values_list('sample_barcode','case_barcode')))
 
                     cohort_sample_list = []
 
@@ -1871,7 +1871,7 @@ def set_operation(request):
 
                     stop = time.time()
 
-                    logger.debug('[BENCHMARKING] Time to build intersecting sample set: ' + (stop - start).__str__())
+                    logger.debug('[BENCHMARKING] Time to create intersecting sample set: ' + (stop - start).__str__())
 
             elif op == 'complement':
                 base_id = request.POST.get('base-id')

--- a/cohorts/views.py
+++ b/cohorts/views.py
@@ -178,6 +178,7 @@ urlfetch.set_default_fetch_deadline(60)
 
 MAX_FILE_LIST_ENTRIES = settings.MAX_FILE_LIST_REQUEST
 MAX_SEL_FILES = settings.MAX_FILES_IGV
+WHITELIST_RE = settings.WHITELIST_RE
 BQ_SERVICE = None
 
 logger = logging.getLogger(__name__)
@@ -1515,6 +1516,16 @@ def save_cohort(request, workbook_id=None, worksheet_id=None, create_workbook=Fa
 
     if request.POST:
         name = request.POST.get('name')
+        whitelist = re.compile(WHITELIST_RE,re.UNICODE)
+        match = whitelist.search(unicode(name))
+        if(match):
+            # XSS risk, log and fail this cohort save
+            match = whitelist.findall(unicode(name))
+            logger.error('[ERROR] While saving a cohort, saw a malformed name: '+name+', characters: '+match.__str__())
+            messages.error(request, "Your cohort's name contains invalid characters; please choose another name." )
+            redirect_url = reverse('cohort_list')
+            return redirect(redirect_url)
+
         source = request.POST.get('source')
         filters = request.POST.getlist('filters')
         apply_filters = request.POST.getlist('apply-filters')

--- a/cohorts/views.py
+++ b/cohorts/views.py
@@ -1147,6 +1147,8 @@ def metadata_counts_platform_list(req_filters, cohort_id, user, limit):
     if req_filters is not None:
         try:
             for key in req_filters:
+                if not validate_filter_key(key):
+                    raise Exception('Invalid filter key received: '+ key)
                 this_filter = req_filters[key]
                 if key not in filters:
                     filters[key] = {'values': []}


### PR DESCRIPTION
- Cohort names will now be tested against a whitelist in the view prior to being saved
- Filters now double-check the column name for presence in the shortlist prior to querying, as a secondary measure

**Note:** Requires #333 from WebApp