### PR TITLE
Sprint 19 sp

### DIFF
--- a/accounts/models.py
+++ b/accounts/models.py
@@ -87,6 +87,15 @@ class UserAuthorizedDatasets(models.Model):
     nih_user = models.ForeignKey(NIH_User, null=False)
     authorized_dataset = models.ForeignKey(AuthorizedDataset, null=False)
 
+    class Meta:
+        unique_together = (("nih_user", "authorized_dataset"),)
+
+    def __str__(self):
+        return "UserAuthorizedDataset({}, {})".format(self.nih_user.NIH_username,self.authorized_dataset.whitelist_id)
+
+    def __repr__(self):
+        return self.__str__()
+
 
 class ServiceAccount(models.Model):
     google_project = models.ForeignKey(GoogleProject, null=False)

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -487,22 +487,22 @@ def verify_service_account(gcp_id, service_account, datasets, user_email, is_ref
                                        'registered_user': registered_user})
 
                 elif member.startswith('serviceAccount'):
-                    if member.find(':'+service_account) > 0:
+                    if member.split(':')[1] == service_account:
                         verified_sa = True
 
         # 2. Verify that the current user is a member of the GCP project
         if not is_email_in_iam_roles(roles, user_email):
-            logging.info('{0}: User email {1} is not the IAM policy of project {2}.'.format(service_account, user_email, gcp_id))
+            logger.info('[STATUS] While verifying SA {0}: User email {1} is not the IAM policy of project {2}.'.format(service_account, user_email, gcp_id))
             st_logger.write_struct_log_entry(log_name, {
-                'message': '{0}: User email {1} is not the IAM policy of project {2}.'.format(service_account, user_email, gcp_id)
+                'message': 'While verifying SA {0}: User email {1} is not the IAM policy of project {2}.'.format(service_account, user_email, gcp_id)
             })
             return {'message': 'You must be a member of a project in order to register it'}
 
         # 3. VERIFY SERVICE ACCOUNT IS IN THIS PROJECT
         if not verified_sa:
-            logging.info('Provided service account does not exist in project.')
+            logger.info('[STATUS] While verifying SA {0}: Provided service account does not exist in project {1}.'.format(service_account, gcp_id))
 
-            st_logger.write_struct_log_entry(log_name, {'message': '{0}: Provided service account does not exist in project {1}.'.format(service_account, gcp_id)})
+            st_logger.write_struct_log_entry(log_name, {'message': 'While verifying SA {0}: Provided service account does not exist in project {1}.'.format(service_account, gcp_id)})
             # return error that the service account doesn't exist in this project
             return {'message': 'The provided service account does not exist in the selected project'}
 

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -184,7 +184,6 @@ def unlink_accounts_and_get_acl_tasks(user_id):
 
 @login_required
 def unlink_accounts(request):
-    logger.info("[STATUS] In unlink accounts")
     user_id = request.user.id
 
     try:


### PR DESCRIPTION
- Fix for #2042
- Logging fixes
- Fixed an issue where GCPs weren't being properly assessed for service account membership
- Partial fix for #2038, change to UserAuthorziedDatasets: each pair of User/Dataset must be unique 