### PR TITLE
Sprint 21 hotfixes

### DIFF
--- a/cohorts/views.py
+++ b/cohorts/views.py
@@ -867,6 +867,8 @@ def export_cohort(request):
 def export_cohort_to_bq(request, cohort_id=0):
     if debug: logger.debug('Called ' + sys._getframe().f_code.co_name)
 
+    redirect_url = reverse('cohort_list') if not cohort_id else reverse('cohort_details', args=[cohort_id])
+
     try:
 
         req_user = User.objects.get(id=request.user.id)
@@ -921,8 +923,6 @@ def export_cohort_to_bq(request, cohort_id=0):
             return JsonResponse(result, status=status)
 
         # POST is to actually export the cohort(s) to a chosen project:dataset:table
-
-        redirect_url = reverse('cohort_list')
 
         dataset = None
         table = None
@@ -984,7 +984,6 @@ def export_cohort_to_bq(request, cohort_id=0):
 
         # If BQ insertion fails, we warn the user
         if 'insertErrors' in bq_result:
-            redirect_url = reverse('cohort_list')
             err_msg = ''
             if len(bq_result['insertErrors']) > 1:
                 err_msg = 'There were ' + str(len(bq_result['insertErrors'])) + ' insertion errors '

--- a/google_helpers/cohort_bigquery.py
+++ b/google_helpers/cohort_bigquery.py
@@ -188,14 +188,15 @@ class BigQueryCohortSupport(object):
         bigquery_service = get_bigquery_service()
         datasets = bigquery_service.datasets().list(projectId=self.project_id).execute()
 
-        for dataset in datasets['datasets']:
-            tables = bigquery_service.tables().list(projectId=self.project_id,datasetId=dataset['datasetReference']['datasetId']).execute()
-            if 'tables' not in tables:
-                bq_tables.append({'dataset': dataset['datasetReference']['datasetId'],
-                                  'table_id': None})
-            else:
-                for table in tables['tables']:
-                    bq_tables.append({'dataset': dataset['datasetReference']['datasetId'], 'table_id':  table['tableReference']['tableId']})
+        if 'datasets' in datasets:
+            for dataset in datasets['datasets']:
+                tables = bigquery_service.tables().list(projectId=self.project_id,datasetId=dataset['datasetReference']['datasetId']).execute()
+                if 'tables' not in tables:
+                    bq_tables.append({'dataset': dataset['datasetReference']['datasetId'],
+                                      'table_id': None})
+                else:
+                    for table in tables['tables']:
+                        bq_tables.append({'dataset': dataset['datasetReference']['datasetId'], 'table_id':  table['tableReference']['tableId']})
 
         return bq_tables
 

--- a/google_helpers/cohort_bigquery.py
+++ b/google_helpers/cohort_bigquery.py
@@ -188,7 +188,7 @@ class BigQueryCohortSupport(object):
         bigquery_service = get_bigquery_service()
         datasets = bigquery_service.datasets().list(projectId=self.project_id).execute()
 
-        if 'datasets' in datasets:
+        if datasets and 'datasets' in datasets:
             for dataset in datasets['datasets']:
                 tables = bigquery_service.tables().list(projectId=self.project_id,datasetId=dataset['datasetReference']['datasetId']).execute()
                 if 'tables' not in tables:


### PR DESCRIPTION
-> Bugfix: redirect_url ref before use, also, redirect to cohort details page, not list page
-> Bugfix: if there are no datasets, the object returned from the CRM service has no datasets key