### PR TITLE
Add a num_retries to logging and better exception analysis

### DIFF
--- a/google_helpers/stackdriver.py
+++ b/google_helpers/stackdriver.py
@@ -72,13 +72,15 @@ class StackDriverLogger(object):
         }
 
         try:
-            response = client.entries().write(body=body).execute()
+            # try this a few times to avoid the deadline exceeded problem
+            response = client.entries().write(body=body).execute(num_retries=2)
 
             if response:
                 logger.error("Unexpected response from logging API: {}".format(response))
 
         except Exception as e:
-            logger.error("Exception while calling logging API.")
+            # If we still get an exception, figure out what the type is:
+            logger.error("Exception while calling logging API: {0}.".format(e.__class__.__name__))
             logger.exception(e)
 
     def write_struct_log_entry(self, log_name, log_entry, severity="DEFAULT"):


### PR DESCRIPTION
A partial fix to #2291. We should retry a couple of times if Google Stackdriver API times out (it only waits five seconds, I believe).