### PR TITLE
Fixed the stage names in the pathologic_stage filter for bug 2697

### DIFF
--- a/cohorts/metadata_helpers.py
+++ b/cohorts/metadata_helpers.py
@@ -603,6 +603,12 @@ def get_preformatted_values(program=None):
                     PREFORMATTED_VALUES[str(pubprog['id'])].append(row[0])
                 cursor.close()
 
+            # Bug ticket 2697: pathologic stage display incorrect because 'pathologic stage'
+            # not included in the preformatted values dataset. This is a fix after the database
+            # has been read
+            for key in PREFORMATTED_VALUES:
+                PREFORMATTED_VALUES.get(key).append('pathologic_stage')
+
         if program not in PREFORMATTED_VALUES:
             return []
 


### PR DESCRIPTION
https://github.com/isb-cgc/software-engineering-coordination/issues/2697

The problem is because pathologic_stage is not part of the preformatted values list. So when the code gets the strings from the database it will format the values and treat them as English words. The fix should be add pathologic_stage to the list.

I currently fix this by appending pathologic_stage  to the PREFORMATTED_VALUES after the database has been read. I think we also can add pathologic_stage into the list in the database, but I do not know which ways is preferred and how to modify the database. It would be great If someone can provide suggestion.