### PR TITLE
Fixed the share button broken for saved cohorts list page#2706

### DIFF
--- a/cohorts/views.py
+++ b/cohorts/views.py
@@ -637,7 +637,7 @@ def cohorts_list(request, is_public=False, workbook_id=0, worksheet_id=0, create
     for cohort in cohort_id_names:
         cohort_listing.append({
             'value': int(cohort['id']),
-            'label': escape(cohort['name'])#.encode('utf8')
+            'label': escape(cohort['name'])
         })
     workbook = None
     worksheet = None

--- a/cohorts/views.py
+++ b/cohorts/views.py
@@ -637,7 +637,7 @@ def cohorts_list(request, is_public=False, workbook_id=0, worksheet_id=0, create
     for cohort in cohort_id_names:
         cohort_listing.append({
             'value': int(cohort['id']),
-            'label': escape(cohort['name']).encode('utf8')
+            'label': escape(cohort['name'])#.encode('utf8')
         })
     workbook = None
     worksheet = None


### PR DESCRIPTION
https://github.com/isb-cgc/software-engineering-coordination/issues/2706
I found the root cause is in cohorts/views.py. There is a for loop that appends to cohorts_listing. And the "label" do a encode(utf-8) on the string. I searched Python documentation and it says the result will look like b'mi_cohort'. And this format is not valid in cohort_list.html. So eventually the shared_users variable is undefined because it is after the cohort_list variable that failed. I removed encode() call and it works. Is this a good fix? I am not sure because I worry encoding is needed.
![image](https://user-images.githubusercontent.com/58752821/72556718-0fb2b600-3854-11ea-9bed-fbba63537ff4.png)
![image](https://user-images.githubusercontent.com/58752821/72556752-235e1c80-3854-11ea-87c7-8b5bef33bafa.png)
