### PR TITLE
Sprint 43

### DIFF
--- a/cohorts/file_helpers.py
+++ b/cohorts/file_helpers.py
@@ -132,7 +132,7 @@ def cohort_files(cohort_id, inc_filters=None, user=None, limit=25, page=1, offse
 
                 facet_attr = Attribute.objects.filter(name__in=facet_names)
 
-            unique="file_gdc_id"
+            unique="file_name_key"
 
         if 'case_barcode' in inc_filters:
             inc_filters['case_barcode'] = ["*{}*".format(x) for x in inc_filters['case_barcode']]


### PR DESCRIPTION
-> #2821: File records without file_gdc_ids were producing 0s in faceted counts; use file_name_key instead.
-> #2820: Same fix as above
-> unique counts weren't always being done for some facet buckets