### PR TITLE
Allow filelist generation without persisting cohort 

### DIFF
--- a/cohorts/file_helpers.py
+++ b/cohorts/file_helpers.py
@@ -154,12 +154,19 @@ def cohort_files(cohort_id, inc_filters=None, case_filters=None, program_ids=Non
 
             file_collection_name = file_collection.name.lower()
 
-            if file_collection_name.startswith('files'):
-                cohort_cases = get_cohort_cases(cohort_id)
-                solr_query['queries']['cohort'] = "{!terms f=case_barcode}" + "{}".format(",".join([x['case_barcode'] for x in cohort_cases]))
+            #GW - this conditional is messing up cohort files. Is it necessary??
+            #if file_collection_name.startswith('files'):
+            cohort_cases = get_cohort_cases(cohort_id)
+            solr_query['queries']['cohort'] = "{!terms f=case_barcode}" + "{}".format(",".join([x['case_barcode'] for x in cohort_cases]))
+
         elif case_filters is not None:
             if not solr_query:
                 solr_query = {'queries': {}}
+            if program_ids is None:
+                program_ids=[]
+                for keyset in case_filters:
+                    progid=keyset.split(":")[0]
+                    program_ids.append(progid)
             cohort_cases  =get_cohort_cases(None, filters=case_filters, program_ids=program_ids)
             solr_query['queries']['cohort'] = "{!terms f=case_barcode}" + "{}".format(",".join([x['case_barcode'] for x in cohort_cases]))
 

--- a/cohorts/file_helpers.py
+++ b/cohorts/file_helpers.py
@@ -38,7 +38,7 @@ FILTER_DATA_TYPE = {
 }
 
 
-def cohort_files(cohort_id, inc_filters=None, user=None, limit=25, page=1, offset=0, sort_column='col-program',
+def cohort_files(cohort_id, inc_filters=None, case_filters=None, program_ids=None,user=None, limit=25, page=1, offset=0, sort_column='col-program',
                  sort_order=0, data_type=None, do_filter_count=True):
 
     if cohort_id and (not user or user.is_anonymous):
@@ -157,6 +157,11 @@ def cohort_files(cohort_id, inc_filters=None, user=None, limit=25, page=1, offse
             if file_collection_name.startswith('files'):
                 cohort_cases = get_cohort_cases(cohort_id)
                 solr_query['queries']['cohort'] = "{!terms f=case_barcode}" + "{}".format(",".join([x['case_barcode'] for x in cohort_cases]))
+        elif case_filters is not None:
+            if not solr_query:
+                solr_query = {'queries': {}}
+            cohort_cases  =get_cohort_cases(None, filters=case_filters, program_ids=program_ids)
+            solr_query['queries']['cohort'] = "{!terms f=case_barcode}" + "{}".format(",".join([x['case_barcode'] for x in cohort_cases]))
 
         if format_filter:
             format_query = build_solr_query(format_filter, with_tags_for_ex=False)

--- a/cohorts/models.py
+++ b/cohorts/models.py
@@ -270,24 +270,29 @@ class Cohort(models.Model):
     # for use in UI display
     def get_filters_for_ui(self, with_display_vals=False):
         cohort_filters = self.get_filters_as_dict()
-        ui_filters = {}
-        attribute_display_vals = {}
-
-        for fg in cohort_filters:
-            for filter in fg['filters']:
-                if filter['program_name'] not in ui_filters:
-                    ui_filters[filter['program_name']] = []
-                ui_filter = filter
-                if filter['id'] not in attribute_display_vals:
-                    attr = Attribute.objects.get(id=filter['id'])
-                    attribute_display_vals[attr.id] = attr.get_display_values()
-                values = filter['values']
-                ui_filter['values'] = []
-                for val in values:
-                    ui_filter['values'].append({'value': val, 'display_val': attribute_display_vals[filter['id']].get(val,val) })
-                ui_filters[filter['program_name']].append(ui_filter)
-
+        ui_filters=get_filters_for_ui(cohort_filters,with_display_vals=False)
         return ui_filters
+
+def get_filters_for_ui(cohort_filters,with_display_vals=False):
+    ui_filters = {}
+    attribute_display_vals = {}
+
+    for fg in cohort_filters:
+        for filter in fg['filters']:
+            if filter['program_name'] not in ui_filters:
+                ui_filters[filter['program_name']] = []
+            ui_filter = filter
+            if filter['id'] not in attribute_display_vals:
+                attr = Attribute.objects.get(id=filter['id'])
+                attribute_display_vals[attr.id] = attr.get_display_values()
+            values = filter['values']
+            ui_filter['values'] = []
+            for val in values:
+                ui_filter['values'].append(
+                    {'value': val, 'display_val': attribute_display_vals[filter['id']].get(val, val)})
+            ui_filters[filter['program_name']].append(ui_filter)
+
+    return ui_filters
 
 
 class Cohort_Perms(models.Model):

--- a/cohorts/utils.py
+++ b/cohorts/utils.py
@@ -114,7 +114,7 @@ def delete_cohort(user, cohort_id):
 
 # Expects a filter format of:
 # { program.id: { attribute.id: { 'values': [...] }, [...] }, [...] }
-def create_cohort(user, filters=None, name=None, desc=None, source_id=None, version=None, stats=None, case_insens=True):
+def create_cohort(user, filters=None, name=None, desc=None, source_id=None, version=None, stats=None, case_insens=True, persist=True):
 
     if not filters and not name and not desc:
         logger.error("[ERROR] Can't create/edit a cohort when nothing is being changed!")
@@ -149,11 +149,12 @@ def create_cohort(user, filters=None, name=None, desc=None, source_id=None, vers
         settings['sample_count'] = stats.get('sample_barcode', 0)
 
     cohort = Cohort.objects.create(**settings)
-    cohort.save()
+    if persist:
+        cohort.save()
 
-    # Set permission for user to be owner
-    perm = Cohort_Perms(cohort=cohort, user=user, perm=Cohort_Perms.OWNER)
-    perm.save()
+        # Set permission for user to be owner
+        perm = Cohort_Perms(cohort=cohort, user=user, perm=Cohort_Perms.OWNER)
+        perm.save()
 
     # TODO: Need to convert filters into a datasource attribute set
     # Make and save filters

--- a/cohorts/views.py
+++ b/cohorts/views.py
@@ -445,7 +445,6 @@ def save_cohort(request):
             #solr_filters={x: {"{}:{}".format(x, attrs[w].name): z} for x, y in filter_obj.items() for w,z in y.items() }
             results = get_cohort_stats(filters=solr_filters, sources=data_sources)
 
-            #results = get_cohort_stats(filters={x: {"{}:{}".format(x, attrs[w].name): z} for x, y in filter_obj.items() for w,z in y.items() }, sources=data_sources)
 
             # Do not allow 0 case cohorts
             if not results["case_barcode"]:

--- a/cohorts/views.py
+++ b/cohorts/views.py
@@ -774,24 +774,54 @@ def filelist(request, cohort_id=None, panel_type=None):
         case_filters={}
         program_ids =[]
         case_filters_disp = {}
+        current_case_filters_disp ={}
+
         if cohort_id:
             cohort = Cohort.objects.get(id=cohort_id, active=True)
             programs_this_cohort = [x for x in cohort.get_programs().values_list('name', flat=True)]
             download_url = reverse("download_cohort_filelist", kwargs={'cohort_id': cohort_id})
             export_url = reverse("export_cohort_data", kwargs={'cohort_id': cohort_id, 'export_type': 'file_manifest'})
+            current_case_filters_disp= cohort.get_filters_for_ui(True)
+            total_samples=cohort.sample_count
+            total_cases=cohort.case_count
         else:
             case_filters = json.loads(req.get('case_filters', '{}'))
             program_ids = json.loads(req.get('program_ids', '[]'))
 
+            solr_filters={}
             for case_filterids in case_filters:
                 progid, attr_nm=case_filterids.split(':')
+                progid=int(progid)
                 prognm=Program.objects.get(id=progid).name
-                if not prognm in case_filters_disp:
-                    case_filters_disp[prognm]=[]
+
+                if not progid in solr_filters:
+                    solr_filters[progid]={}
+                solr_filters[progid][case_filterids]=case_filters[case_filterids]
+
+                if not prognm in current_case_filters_disp:
+                    current_case_filters_disp[prognm]=[]
                 attr = Attribute.objects.get(name=attr_nm)
+                #attr_node=attr.name.split("_")[1].upper()
+
+
                 attr_disp=attr.display_name
+                #if "_" in attr.name:
+                #    attr_disp = "[" + attr.name.split("_")[1].upper() + "]" + attr_disp
+
                 filter_values = case_filters[case_filterids]['values']
-                case_filters_disp[prognm].append({"attr_nm":attr_disp, 'values':filter_values})
+
+                disp_val=[{"values":val, "display_val":val} for val in filter_values]
+                current_case_filters_disp[prognm].append({"id":attr.id, "attr_name":attr.name, "name":attr.name, "display_name":attr_disp, "op":'OR', "values":disp_val})
+
+            data_sources = DataSource.objects.select_related("version").filter(source_type=DataSource.SOLR,
+                                                                               version__active=True).prefetch_related(
+                Prefetch('datasettypes', queryset=DataSetType.objects.filter(
+                    data_type__in=[DataSetType.CLINICAL_DATA, DataSetType.FILE_TYPE_DATA]))
+            ).filter(datasettypes__set_type__in=[DataSetType.CASE_SET, DataSetType.FILE_AVAIL_SET]).distinct()
+
+            results = get_cohort_stats(filters=solr_filters, sources=data_sources)
+            total_samples=results['sample_barcode']
+            total_cases=results['case_barcode']
 
             download_url = reverse("download_filelist")
             export_url = reverse("export_data", kwargs={'export_type': 'file_manifest'})
@@ -802,9 +832,11 @@ def filelist(request, cohort_id=None, panel_type=None):
                                             'total_file_count': (items['total_file_count'] if items else 0),
                                             'download_url': download_url,
                                             'export_url': export_url,
-                                             'case_filters':case_filters,
-                                             'case_filters_disp':case_filters_disp,
-                                             'program_ids':program_ids,
+                                            'total_samples': total_samples,
+                                            'total_cases': total_cases,
+                                            'current_case_filters_disp': current_case_filters_disp,
+                                            'case_filters':case_filters,
+                                            'program_ids':program_ids,
                                             'metadata_data_attr': metadata_data_attr,
                                             'file_list': (items['file_list'] if items else []),
                                             'file_list_max': MAX_FILE_LIST_ENTRIES,
@@ -866,8 +898,11 @@ def filelist_ajax(request, cohort_id=None, panel_type=None):
             request.POST.get('filters', '{}'))
         if request.GET.get('case_barcode', None):
             inc_filters['case_barcode'] = [request.GET.get('case_barcode')]
+        case_filters=None
+        if request.GET.get('case_filters', None):
+            case_filters = json.loads(request.GET.get('case_filters','{}'))
 
-        result = cohort_files(cohort_id, user=request.user, inc_filters=inc_filters,
+        result = cohort_files(cohort_id, user=request.user, inc_filters=inc_filters, case_filters=case_filters,
                               data_type=panel_type, do_filter_count=do_filter_count, **params)
 
         # If nothing was found, our  total file count will reflect that


### PR DESCRIPTION
Users can select clinical filters, then open files for the resulting cohort without first persisting the cohort